### PR TITLE
Fix multiple uploads image bug

### DIFF
--- a/webapp/components/PictureUpload.tsx
+++ b/webapp/components/PictureUpload.tsx
@@ -14,19 +14,18 @@ type Props = {
 const PictureUpload = ({ updateForm }: Props): JSX.Element => {
   const [images, setImages] = useState<Array<string>>([]);
   const [names, setNames] = useState<string[]>([]);
-  const [total, setTotal] = useState(0);
+
   useEffect(() => {
-    if (images.length === total) updateForm(images);
-  }, [images, total]);
+    updateForm(images);
+  }, [images]);
 
   const removeImage = (i: number) => {
     const newImages = images;
     const newNames = names;
     newImages.splice(i, 1);
     newNames.splice(i, 1);
-    setImages(newImages);
+    setImages([...newImages]);
     setNames(newNames);
-    setTotal(total - 1);
   };
 
   return (
@@ -39,7 +38,6 @@ const PictureUpload = ({ updateForm }: Props): JSX.Element => {
             multiple
             onChange={(e) => {
               const files = e.target.files || [];
-              setTotal(files.length);
               for (let i = 0; i < files.length; i++) {
                 setNames((prevNames) => [...prevNames, files[i].name]);
                 const reader = new FileReader();


### PR DESCRIPTION
There is currently a bug where, if you upload multiple attachments in succession, only the first attachment will be added to the real state. There will be a visual bug where it looks like you have uploaded two attachments, but the form state only registered the first upload.

You could however upload multiple attachments by selecting multiple attachments in the initial upload, which is why this bug has flown under the radar for many years.

![image](https://user-images.githubusercontent.com/23152018/137194504-b6df2811-110b-4ce4-b5dd-2044b2039810.png)
