### PR TITLE
Fix scroll bug by targeting ReactModalPoral CSS

### DIFF
--- a/webapp/pages/_app.css
+++ b/webapp/pages/_app.css
@@ -15,6 +15,10 @@ body > div {
   height: 100%;
 }
 
+.ReactModalPortal {
+  height: 0 !important;
+}
+
 html,
 body {
   margin: 0;


### PR DESCRIPTION
In prod, you can scroll far past the page due to a div height CSS global style. This targets the modal, and sets the portal to 0.
![Screenshot 2021-10-16 at 17 05 24](https://user-images.githubusercontent.com/23152018/137592412-7c89d8e9-295a-45c6-b9c2-60f29a859903.png)
