### PR TITLE
Add requested received-date to the PDF

### DIFF
--- a/kaaf/handler.py
+++ b/kaaf/handler.py
@@ -9,6 +9,7 @@ import operator
 from fpdf import FPDF
 from PIL import Image
 from sentry_sdk import configure_scope
+from email.utils import formatdate
 
 # Handle PDF files
 from pdf2image import convert_from_path
@@ -140,7 +141,7 @@ def create_pdf(data):
     signature = data.pop("signature")
     images = data.pop("images")
 
-    pdf.cell(0, 14, "Kvitteringsskjema", ln=1)
+    pdf.cell(0, 14, f'Kvitteringsskjema mottatt {formatdate(localtime=True)}', ln=1)
 
     pdf.set_font("Arial", "", 12)
     for key in field_title_map.keys():


### PR DESCRIPTION
This is for later review. Only the PDF is uploaded to the accounting program, so one can't see the date the email was received.

![Screenshot 2022-03-23 at 14 02 46](https://user-images.githubusercontent.com/23152018/159706430-50d88bd1-0669-44bf-ba3a-615c2d0f6069.png)

