### PR TITLE
Add modulo-11 validator to accountNumber

### DIFF
--- a/webapp/cypress/e2e/index.cy.js
+++ b/webapp/cypress/e2e/index.cy.js
@@ -11,7 +11,7 @@ describe('Form', () => {
     cy.get('#mailFrom').type('jon@doe.com');
     cy.get('#committee').type('webkom');
     cy.get('#mailTo').type('lisa@doe.com');
-    cy.get('#accountNumber').type('1000 10 10000');
+    cy.get('#accountNumber').type('1234 56 78903');
     cy.get('#amount').type('1000');
     cy.get('#date').type('1970-01-01');
     cy.get('#occasion').type('Cypress');
@@ -66,7 +66,7 @@ describe('Submit', () => {
     cy.get('#mailFrom').type('jon@doe.com');
     cy.get('#committee').type('webkom');
     cy.get('#mailTo').type('lisa@doe.com');
-    cy.get('#accountNumber').type('1000 10 10000');
+    cy.get('#accountNumber').type('1234 56 78903');
     cy.get('#amount').type('1000');
     cy.get('#date').type('1970-01-01');
     cy.get('#occasion').type('Cypress');

--- a/webapp/utils/validators.ts
+++ b/webapp/utils/validators.ts
@@ -32,4 +32,16 @@ export const accountValidator: FieldValidator = (value?: string) => {
   if (String(value ?? '').replaceAll(' ', '').length !== 11) {
     return 'Kontonummeret må bestå av 11 siffer';
   }
+
+  // Modulo-based validation as per https://no.wikipedia.org/wiki/MOD11
+  // The last 1 is added to add the control-digit, and the sum should be divisible by 11
+  const weights = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2, 1];
+  let sum = 0;
+  value
+    ?.replaceAll(' ', '')
+    .split('')
+    .forEach((digit, index) => (sum += Number(digit) * weights[index]));
+  if (sum % 11 !== 0) {
+    return 'Kontonummeret er ugyldig';
+  }
 };


### PR DESCRIPTION
This should prevent most invalid account numbers from being sent.

If you're in doubt, feel free to test some of yours on https://kvittering-dev.abakus.no/

Resolves ABA-762