### PR TITLE
Check if data is present before adding it to pdf

### DIFF
--- a/server/handler.py
+++ b/server/handler.py
@@ -150,7 +150,8 @@ def create_pdf(data):
         pdf.set_font("", "B")
         pdf.cell(90, 5, txt=field_title_map[key])
         pdf.set_font("", "")
-        pdf.multi_cell(0, 5, txt=data[key])
+        field_value = data[key] if key in data else ""
+        pdf.multi_cell(0, 5, txt=field_value)
 
     pdf.set_font("", "B")
     pdf.cell(0, 5, txt="Signatur:", ln=1)


### PR DESCRIPTION
Comment is not mandatory, so it is not validated before adding it to the pdf, causing an error. This should fix that.

Previously hasn't been much of an issue as comment was always sent with the form - but it appears `react-final-form` doesn't.