### PR TITLE
Set Reply-To header to original recipients

### DIFF
--- a/server/mail.py
+++ b/server/mail.py
@@ -52,6 +52,7 @@ def send_mail(mail_to, body, file):
     msg["From"] = mail_from
     msg["To"] = COMMASPACE.join(mail_to)
     msg["Date"] = formatdate(localtime=True)
+    msg["Reply-To"] = COMMASPACE.join(mail_to)
 
     create_mail(msg, body)
 


### PR DESCRIPTION
The email sent from the system is normally used as a thread. Currently you have to either select the emails manually or hit reply all and remove the sender email.

Needs a quick bit of testing to verify that it works how I think it does