### PR TITLE
Store form in local- and sessionStorage

### DIFF
--- a/webapp/utils/debounce.ts
+++ b/webapp/utils/debounce.ts
@@ -1,0 +1,9 @@
+export const debounce = (func: (...args: any) => void, timeout = 300) => {
+  let timer: NodeJS.Timeout;
+  return (...args: any) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      func.apply(this, args);
+    }, timeout);
+  };
+};


### PR DESCRIPTION
Allows users to refresh - autofills their name and email if they've filled it in before, and all the information if they're in the same session.

This would wipe all the other information if the tab is closed, but I would rather have it that way than storing their account numbers permanently on their computers and only wiping them when they re-visit the site.


Resolves ABA-758
Resolves https://github.com/webkom/kvittering/issues/122