### PR TITLE
Improve error handling of invalid data input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ webapp/cypress/screenshots
 
 .python-version
 .vscode
+
+.DS_store

--- a/server/generate-example.py
+++ b/server/generate-example.py
@@ -2,21 +2,35 @@ import argparse
 import base64
 
 from handler import create_pdf
+from handler import get_missing_fields
 from handler import modify_data
+from handler import validate_fields
 
 
 default_data = {
     "date": "11-03-2020",
-    "amount": "153",
+    "amount": 0.25,
     "name": "Lar",
-    "accountNumber": "010101010101",
-    "group": "Komkom",
+    "accountNumber": "01010101010",
+    "group": "KomKom",
     "occasion": "Teste litt",
     "comment": "pls",
+    "mailTo": "test@demo.com",
+    "mailFrom": "test2@demo.com",
 }
 
 
 def main(data, out):
+    req_fields = get_missing_fields(data)
+    if len(req_fields) > 0:
+        print(f'Requires fields {", ".join(req_fields)}')
+        return
+
+    validation_errors = validate_fields(data)
+    if len(validation_errors) > 0:
+        print(f'Invalid fields {", ".join(validation_errors)}')
+        return
+
     data = modify_data(data)
 
     pdf = create_pdf(data)


### PR DESCRIPTION
Most importantly;  
* Fix bug that would occur when amount was sent as a number and not a string, which causes most of the errors we've seen in sentry as of late. (this is why I removed the `len()` thingy as it doesn't work well with numbers)

Less importantly;
* Add backend-validation for amount and length of account number
* Make `generate-example.py` run validation as well as generation to use it for local testing