### PR TITLE
Require full name for kvittering

### DIFF
--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -14,7 +14,7 @@ import { BiBlock, BiReceipt } from 'react-icons/bi';
 import { Form } from 'react-final-form';
 import PictureUpload from './PictureUpload';
 import SignatureUpload from './SignatureUpload';
-import { accountValidator, emailValidator } from 'utils/validators';
+import { accountValidator, emailValidator, fullNameValidator } from 'utils/validators';
 import { mailToDataList } from 'utils/datalists';
 import { FormButton, FormInput } from './elements';
 import FormSelect from './elements/FormSelect';
@@ -217,6 +217,7 @@ const ReceiptForm = (): JSX.Element => {
                 required
                 helperText="Ditt fulle navn, slik kvitteringen viser"
                 autoFocus
+                validators={[fullNameValidator]}
               />
 
               <FormInput

--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -14,7 +14,11 @@ import { BiBlock, BiReceipt } from 'react-icons/bi';
 import { Form } from 'react-final-form';
 import PictureUpload from './PictureUpload';
 import SignatureUpload from './SignatureUpload';
-import { accountValidator, emailValidator, fullNameValidator } from 'utils/validators';
+import {
+  accountValidator,
+  emailValidator,
+  fullNameValidator,
+} from 'utils/validators';
 import { mailToDataList } from 'utils/datalists';
 import { FormButton, FormInput } from './elements';
 import FormSelect from './elements/FormSelect';

--- a/webapp/utils/validators.ts
+++ b/webapp/utils/validators.ts
@@ -14,11 +14,14 @@ export const requiredValidator: FieldValidator = (value?: string) =>
   value ? undefined : 'Dette feltet er obligatorisk';
 
 export const fullNameValidator: FieldValidator = (value?: string) => {
-  const namesWithlength = value?.split(" ").filter(name => name.length > 0);
-  if (!value?.includes(' ') ||  !namesWithlength || namesWithlength?.length < 2) {
+  const namesWithlength = value?.split(' ').filter((name) => name.length > 0);
+  if (
+    !value?.includes(' ') ||
+    !namesWithlength ||
+    namesWithlength?.length < 2
+  ) {
     return 'Vennligst skriv inn ditt fulle navn';
   }
-  
 };
 
 export const emailValidator: FieldValidator = (value?: string) => {

--- a/webapp/utils/validators.ts
+++ b/webapp/utils/validators.ts
@@ -13,6 +13,14 @@ export const validateField =
 export const requiredValidator: FieldValidator = (value?: string) =>
   value ? undefined : 'Dette feltet er obligatorisk';
 
+export const fullNameValidator: FieldValidator = (value?: string) => {
+  const namesWithlength = value?.split(" ").filter(name => name.length > 0);
+  if (!value?.includes(' ') ||  !namesWithlength || namesWithlength?.length < 2) {
+    return 'Vennligst skriv inn ditt fulle navn';
+  }
+  
+};
+
 export const emailValidator: FieldValidator = (value?: string) => {
   if (!value?.includes('@')) {
     return 'E-post må inneholde @';


### PR DESCRIPTION
Made a validator for name. Name now has to include a space.  

I did also make it such that at least two of the names had to be more than 0 in length. This was added because writing your first name and just a space would validate you name while not being a real name. Initially , I did think about having two names with at least 2 letters (so not just initals) but could not find any sources on length of a name. ( In case we invalidate a name such as Å, even thought that is a persons full first or last name).

I do really appreciate input on this topic.

Resolves ABA-1075