### PR TITLE
Add send to button name

### DIFF
--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -338,7 +338,7 @@ const ReceiptForm = (): JSX.Element => {
 
             <Spacer y={4} />
 
-            <div className="flex gap-4">
+            <div className="flex flex-col sm:flex-row gap-4">
               <FormButton
                 startContent={<BiBlock size={24} />}
                 disabled={values === getInitialValues()}
@@ -371,7 +371,7 @@ const ReceiptForm = (): JSX.Element => {
                   )
                 }
               >
-                Generer kvittering
+                Generer og send kvittering
               </FormButton>
             </div>
 

--- a/webapp/cypress/e2e/index.cy.js
+++ b/webapp/cypress/e2e/index.cy.js
@@ -73,7 +73,7 @@ describe('Submit', () => {
     cy.get('#attachments').attachFile('abakus.png');
 
     // Submit
-    cy.get('button').contains('Generer kvittering').click();
+    cy.get('button').contains('Generer og send kvittering').click();
 
     // Wait for the submitResponse
     cy.wait('@submitResponse')


### PR DESCRIPTION
I thought this button should say exactly what it does, and I made it wrap properly on mobile (needed now that the text is longer).  


Narrow screens:  
| Before | After |
| --- | --- |
| <img width="340" alt="Skjermbilde 2024-10-02 kl  10 42 59" src="https://github.com/user-attachments/assets/58858fcb-27d9-4f52-ad75-faca7a4b3b41"> | <img width="296" alt="Skjermbilde 2024-10-02 kl  10 43 37" src="https://github.com/user-attachments/assets/bc8a8d10-395a-41e8-91b1-8a7d04f0b720"> |