### PR TITLE
Add warning and success colors to action buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ webapp/cypress/screenshots
 .vscode
 
 .DS_store
+
+# An input folder for files to test the CLI-generator and the resulting output
+input
+output.pdf

--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
 import {
   Card,
   CardBody,
@@ -9,19 +8,20 @@ import {
   Tab,
   Tabs,
 } from '@nextui-org/react';
+import { useEffect, useMemo, useState } from 'react';
 import type { FormRenderProps } from 'react-final-form';
-import { BiBlock, BiReceipt } from 'react-icons/bi';
 import { Form } from 'react-final-form';
-import PictureUpload from './PictureUpload';
-import SignatureUpload from './SignatureUpload';
+import { BiBlock, BiReceipt } from 'react-icons/bi';
+import { mailToDataList } from 'utils/datalists';
 import {
   accountValidator,
   emailValidator,
   fullNameValidator,
 } from 'utils/validators';
-import { mailToDataList } from 'utils/datalists';
 import { FormButton, FormInput } from './elements';
 import FormSelect from './elements/FormSelect';
+import PictureUpload from './PictureUpload';
+import SignatureUpload from './SignatureUpload';
 
 type FormValues = {
   name: string;
@@ -345,6 +345,7 @@ const ReceiptForm = (): JSX.Element => {
 
             <div className="flex flex-col sm:flex-row gap-4">
               <FormButton
+                color="danger"
                 startContent={<BiBlock size={24} />}
                 disabled={values === getInitialValues()}
                 onPress={() => {
@@ -367,6 +368,14 @@ const ReceiptForm = (): JSX.Element => {
               </FormButton>
               <FormButton
                 type="submit"
+                color={
+                  submitting || hasValidationErrors ? 'default' : 'success'
+                }
+                className={
+                  submitting || hasValidationErrors
+                    ? 'cursor-not-allowed'
+                    : 'cursor-pointer'
+                }
                 disabled={submitting || hasValidationErrors}
                 startContent={<BiReceipt size={24} />}
                 onPress={() =>


### PR DESCRIPTION
Also added some gitignored files to be able to run the script locally with test data without having that test data being tracked by git

## Before
<img width="576" alt="image" src="https://github.com/user-attachments/assets/0f719f3d-c468-4705-91a9-0ceebdee97c5" />

## After
When form is not valid
<img width="571" alt="image" src="https://github.com/user-attachments/assets/9a7ded76-511b-40c6-9363-487b816b50fa" />

When form is valid
<img width="570" alt="image" src="https://github.com/user-attachments/assets/c48ae2d3-d178-469b-a5e2-16f8ec402518" />
