### PR TITLE
Lock poetry to version 1.8.5 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 COPY ./pyproject.toml ./pyproject.toml
 
-RUN pip install poetry
+RUN pip install poetry==1.8.5
 
 RUN set -e \
   && poetry config virtualenvs.create false \


### PR DESCRIPTION
Poetry 2.0.0 has been released as of the 5. of january, and it introduces some breaking changes.

poetry-testbase is still in v1.4.2 (or 1.7.4 if we pushed the newest version of the repo), so now the tests will fail if we migrate, but then if we don't migrate the deployment will fail - so it would be nice to lock this until we update lego-testbase to a newer version

Has been tested