### PR TITLE
Properly clear form when clear button is clicked

### DIFF
--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -350,6 +350,7 @@ const ReceiptForm = (): JSX.Element => {
                 disabled={values === getInitialValues()}
                 onPress={() => {
                   // Clear locally stored variables and reset the form
+                  form.restart();
                   sessionStorage?.clear();
                   localStorage?.clear();
                   const initialValues = getInitialValues();
@@ -360,7 +361,6 @@ const ReceiptForm = (): JSX.Element => {
                         initialValues[valueKey as keyof FormValues]
                       )
                     );
-                    form.restart();
                   });
                 }}
               >


### PR DESCRIPTION
The form deletion didn't work as intended, probably because form.reset reset the values to the previous initialValues (which would keep everything that was stored in localStorage and sessionStorage as well)

Now it clears all fields except the current date, which is what I would expect the button to do.