### PR TITLE
Reduce spacing around the form on mobile

### DIFF
--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -226,6 +226,7 @@ const ReceiptForm = (): JSX.Element => {
 
               <FormInput
                 name="mailFrom"
+                type="email"
                 label="Din e-post"
                 required
                 helperText="En kopi av skjemaet vil bli sendt hit"
@@ -265,6 +266,7 @@ const ReceiptForm = (): JSX.Element => {
                       />
                       <FormInput
                         name="mailTo"
+                        type="email"
                         label="Økans e-post"
                         required
                         helperText="Økans til gruppen/komiteen"

--- a/webapp/pages/_app.css
+++ b/webapp/pages/_app.css
@@ -2,7 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-html,
 body {
   padding: 1rem;
   font-family: Inter, sans-serif;
@@ -13,8 +12,8 @@ body {
 }
 
 @media screen and (max-width: 500px) {
-  html,
   body {
     margin: 1rem 0;
+    padding-top: 0;
   }
 }


### PR DESCRIPTION
There is quite a lot of spacing around the page on mobile, which feels unnecessary.

If you want to get a feel for it I've deployed it to https://kvittering-dev.abakus.no/

<table>
    <tr>
        <td>Before</td>
        <td>After</td>
    </tr>
    <tr>
        <td><img width="366" alt="image" src="https://github.com/user-attachments/assets/aa33370d-ab26-4c80-b3b9-583b70cf620d" /></td>
        <td><img width="365" alt="image" src="https://github.com/user-attachments/assets/86693b0b-8c73-41d6-8865-06355ce1097b" /></td>
    </tr>
</table>