### PR TITLE
 Feature: Add confirmation modal before sending receipt

### DIFF
--- a/webapp/components/ConfirmationModal.tsx
+++ b/webapp/components/ConfirmationModal.tsx
@@ -26,21 +26,19 @@ const ConfirmationModal: React.FC<Props> = ({
     >
       <ModalContent>
         <ModalBody>
-          <p style={{ textAlign: 'center', margin: '0 10px' }}>
+          <p className="mb-3 mt-8 text-center">
             Ved å godkjenne bekrefter jeg at beløpet stemmer med kvitteringen
           </p>
           <FormButton
-            style={{ marginBottom: 10 }}
             type="submit"
             color={submitting || hasValidationErrors ? 'default' : 'success'}
             className={
-              submitting || hasValidationErrors
+              (submitting || hasValidationErrors
                 ? 'cursor-not-allowed'
-                : 'cursor-pointer'
-            }
+                : 'cursor-pointer') + " mb-3"
+            } 
             disabled={submitting || hasValidationErrors}
             startContent={<BiReceipt size={24} />}
-            onSubmit={() => console.log('hei')}
             onPress={() => {
               onOpenChange();
               onSubmitExternal();

--- a/webapp/components/ConfirmationModal.tsx
+++ b/webapp/components/ConfirmationModal.tsx
@@ -35,8 +35,8 @@ const ConfirmationModal: React.FC<Props> = ({
             className={
               (submitting || hasValidationErrors
                 ? 'cursor-not-allowed'
-                : 'cursor-pointer') + " mb-3"
-            } 
+                : 'cursor-pointer') + ' mb-3'
+            }
             disabled={submitting || hasValidationErrors}
             startContent={<BiReceipt size={24} />}
             onPress={() => {

--- a/webapp/components/ConfirmationModal.tsx
+++ b/webapp/components/ConfirmationModal.tsx
@@ -1,0 +1,57 @@
+import { Modal, ModalBody, ModalContent } from '@nextui-org/react';
+import React from 'react';
+import { FormButton } from './elements';
+import { BiReceipt } from 'react-icons/bi';
+
+interface Props {
+  isOpen: boolean;
+  onOpenChange: () => void;
+  submitting: boolean;
+  hasValidationErrors: boolean;
+  onSubmitExternal: () => void;
+}
+
+const ConfirmationModal: React.FC<Props> = ({
+  isOpen,
+  onOpenChange,
+  submitting,
+  hasValidationErrors,
+  onSubmitExternal,
+}) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      className="w-[45vw] max-w-5xl"
+    >
+      <ModalContent>
+        <ModalBody>
+          <p style={{ textAlign: 'center', margin: '0 10px' }}>
+            Ved å godkjenne bekrefter jeg at beløpet stemmer med kvitteringen
+          </p>
+          <FormButton
+            style={{ marginBottom: 10 }}
+            type="submit"
+            color={submitting || hasValidationErrors ? 'default' : 'success'}
+            className={
+              submitting || hasValidationErrors
+                ? 'cursor-not-allowed'
+                : 'cursor-pointer'
+            }
+            disabled={submitting || hasValidationErrors}
+            startContent={<BiReceipt size={24} />}
+            onSubmit={() => console.log('hei')}
+            onPress={() => {
+              onOpenChange();
+              onSubmitExternal();
+            }}
+          >
+            Godkjenn
+          </FormButton>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ConfirmationModal;

--- a/webapp/components/Form.tsx
+++ b/webapp/components/Form.tsx
@@ -22,6 +22,7 @@ import { FormButton, FormInput } from './elements';
 import FormSelect from './elements/FormSelect';
 import PictureUpload from './PictureUpload';
 import SignatureUpload from './SignatureUpload';
+import ConfirmationModal from './ConfirmationModal';
 
 type FormValues = {
   name: string;
@@ -125,6 +126,8 @@ const ReceiptForm = (): JSX.Element => {
   // Hooks for submission
   const [success, setSuccess] = useState<boolean | null>(null);
   const [response, setResponse] = useState<string | null>(null);
+  const [openConfirmationModal, setOpenConfirmationModal] =
+    useState<boolean>(false);
 
   const onSubmit = async (
     values: FormValues,
@@ -369,7 +372,6 @@ const ReceiptForm = (): JSX.Element => {
                 Tilbakestill skjemaet
               </FormButton>
               <FormButton
-                type="submit"
                 color={
                   submitting || hasValidationErrors ? 'default' : 'success'
                 }
@@ -381,14 +383,25 @@ const ReceiptForm = (): JSX.Element => {
                 disabled={submitting || hasValidationErrors}
                 startContent={<BiReceipt size={24} />}
                 onPress={() =>
-                  hasValidationErrors &&
-                  Object.keys(errors ?? {}).forEach((fieldName) =>
-                    form.blur(fieldName as keyof FormValues)
-                  )
+                  hasValidationErrors
+                    ? Object.keys(errors ?? {}).forEach((fieldName) =>
+                        form.blur(fieldName as keyof FormValues)
+                      )
+                    : setOpenConfirmationModal(!openConfirmationModal)
                 }
               >
                 Generer og send kvittering
               </FormButton>
+
+              <ConfirmationModal
+                isOpen={openConfirmationModal}
+                onOpenChange={() =>
+                  setOpenConfirmationModal(!openConfirmationModal)
+                }
+                submitting={submitting}
+                hasValidationErrors={hasValidationErrors}
+                onSubmitExternal={handleSubmit}
+              ></ConfirmationModal>
             </div>
 
             {hasBeenTouched && hasValidationErrors && (

--- a/webapp/cypress/e2e/index.cy.js
+++ b/webapp/cypress/e2e/index.cy.js
@@ -84,6 +84,7 @@ describe('Submit', () => {
 
     // Submit
     cy.get('button').contains('Generer og send kvittering').click();
+    cy.get('button').contains("Godkjenn").click();
 
     // Wait for the submitResponse
     cy.wait('@submitResponse')

--- a/webapp/cypress/e2e/index.cy.js
+++ b/webapp/cypress/e2e/index.cy.js
@@ -84,7 +84,7 @@ describe('Submit', () => {
 
     // Submit
     cy.get('button').contains('Generer og send kvittering').click();
-    cy.get('button').contains("Godkjenn").click();
+    cy.get('button').contains('Godkjenn').click();
 
     // Wait for the submitResponse
     cy.wait('@submitResponse')


### PR DESCRIPTION
 Co-authored-by shailesh shadacharan <shsha001@outlook.com>

# Description

Added a confirmation modal that a user has to confirm before sending through the receipt. The user confirms that the amount put into the online receipt is the exact same as the amount on the original receipt. 

# Result
**Before**

https://github.com/user-attachments/assets/8657dbfb-710c-4fed-97ef-dd52754ff882



**After**

https://github.com/user-attachments/assets/3787d222-bec6-44b4-a360-dd3e256998d3



If you've made visual changes, please check the boxes below and include images showing the changes. Descriptions are appreciated.

- [X] Changes look good with different viewports (mobile, tablet, etc.).
- [X] Changes look good with slower Internet connections.


# Testing

- [X] I have thoroughly tested my changes.

---

Resolves ABA-1327
